### PR TITLE
fix to issue #66

### DIFF
--- a/sqwidget.js
+++ b/sqwidget.js
@@ -1302,7 +1302,7 @@ var Sqwidget;
             }
             // grab script templates - from the HEAD only for templates other than the default
             j = jQuery(templateStr);
-            j.filter("script[type=text/template][id]")
+            j.filter("script[type='text/template'][id]")
              .each(function (i, t) {
                 t = jQuery(t);
                 templates[t.attr("id")] = jQuery.trim(t.html());

--- a/test/test-jquery-compatibility/test-jquery-1.6.3.html
+++ b/test/test-jquery-compatibility/test-jquery-1.6.3.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.6.3 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.3/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>

--- a/test/test-jquery-compatibility/test-jquery-1.6.4.html
+++ b/test/test-jquery-compatibility/test-jquery-1.6.4.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.6.4 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>

--- a/test/test-jquery-compatibility/test-jquery-1.7.1.html
+++ b/test/test-jquery-compatibility/test-jquery-1.7.1.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.7.1 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>

--- a/test/test-jquery-compatibility/test-jquery-1.7.2.html
+++ b/test/test-jquery-compatibility/test-jquery-1.7.2.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.7.2 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>

--- a/test/test-jquery-compatibility/test-jquery-1.8.0.html
+++ b/test/test-jquery-compatibility/test-jquery-1.8.0.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.8.0 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>

--- a/test/test-jquery-compatibility/test-jquery-1.8.1.html
+++ b/test/test-jquery-compatibility/test-jquery-1.8.1.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.8.1 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>

--- a/test/test-jquery-compatibility/test-jquery-1.8.2.html
+++ b/test/test-jquery-compatibility/test-jquery-1.8.2.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JQuery 1.8.2 Tests</title>
+  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js" ></script>
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../sqwidget.js"></script>
+  <div data-sqwidget="src:../../tutorials/templates.html"></div>
+</body>
+</html>


### PR DESCRIPTION
on line 1305 the jquery filter query selector was missing quotes around the "text/template" parameter. Somehow this has worked up to but excluding version 1.8.0 of jquery.

I have also added a test folder with a test-jquery-compatibility  sub folder which has  a widget definition for each jquery version starting with version 1.6.3 up to and including 1.8.2. The widget used is the simple template test but we could change that with a more sophisticated widget that uses more of the jquery dependent functionality of sqwidget.
