### PR TITLE
Strip single-line javascript comments from the html template before generation

### DIFF
--- a/tools/build-crossdomain.js
+++ b/tools/build-crossdomain.js
@@ -19,11 +19,20 @@ function buildTemplate(html, widgetName, doStripwhitespace){
             .replace(/(?=\n)/g, '\\');  // escape end of lines
     }
     
+    // this is very dumb, as it only handles the most
+    // basic of cases - we'd need a full blown parser to cope
+    // with multiline quotes etc
+    function stripComments(txt) {
+        return txt
+            .replace(/\s+\/\/.*/g, '');  // strip quotes      
+    }
+    
     html = escape(
-        doStripwhitespace ?
-            stripwhitespace(html) :
-            html
-    );
+              stripComments(
+                  doStripwhitespace ?
+                  stripwhitespace(html) :
+                  html
+    ));
     
     if (!widgetName){
         alert('No widget name provided');


### PR DESCRIPTION
They prevent the generated js file from working. 

The stripper is really dumb and considers anything after two-forward slashes following a space to be a comment. You'd need a full blown parser to deal with comments, especially multiline, correctly.
