### PR TITLE
Start a GUID with a character for valid CSS class

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -29,7 +29,7 @@ function(bonzo, qwery, Emitter) {
     };
 
     SqwidgetCore.prototype.guid = function() {
-      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      return 'axxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
         var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
         return v.toString(16);
       });


### PR DESCRIPTION
- Classnames starting with digits are not valid css names. Simply
  prefix a guid with a character to enforce validity.
